### PR TITLE
Add GetTodayCloseUtcAsync to IMarketHoursService

### DIFF
--- a/src/MarketData.Application/Contracts/IMarketHoursService.cs
+++ b/src/MarketData.Application/Contracts/IMarketHoursService.cs
@@ -17,4 +17,10 @@ public interface IMarketTimingService
     Task<bool> IsOpenAsync(string venue, DateTimeOffset asOfUtc, CancellationToken ct = default);
 
     Task<MarketHoursStatus> GetCurrentStatusAsync(string venue, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns today's regular-session close time expressed as UTC.
+    /// Returns <c>null</c> when today is not a trading day (weekend, holiday).
+    /// </summary>
+    Task<DateTimeOffset?> GetTodayCloseUtcAsync(string venue, CancellationToken ct = default);
 }

--- a/src/MarketData.Infrastructure/Calendar/NyseMarketHoursService.cs
+++ b/src/MarketData.Infrastructure/Calendar/NyseMarketHoursService.cs
@@ -51,6 +51,23 @@ public sealed class NyseMarketHoursService(ITimeKeeper timeKeeper) : IMarketTimi
         return localTime >= session.Open && localTime < session.Close;
     }
 
+    public async Task<DateTimeOffset?> GetTodayCloseUtcAsync(string venue, CancellationToken ct = default)
+    {
+        EnsureVenue(venue);
+
+        // Resolve "today" in Eastern time, since that's where NYSE lives.
+        DateTimeOffset asOfEastern = TimeZoneInfo.ConvertTime(timeKeeper.Now, MarketTimeZoneProvider.EasternTimeZone);
+        DateOnly today = DateOnly.FromDateTime(asOfEastern.DateTime);
+
+        var session = await GetSessionAsync(venue, today, ct);
+        if (session is null) return null;   // weekend or holiday → no close today
+
+        // Build a DateTimeOffset for today's close in Eastern time, then express as UTC.
+        var closeDateTime = today.ToDateTime(session.Close);
+        var easternOffset = MarketTimeZoneProvider.EasternTimeZone.GetUtcOffset(closeDateTime);
+        return new DateTimeOffset(closeDateTime, easternOffset).ToUniversalTime();
+    }
+
     public async Task<MarketHoursStatus> GetCurrentStatusAsync(string venue, CancellationToken ct = default)
     {
         DateTimeOffset asOfUtc = timeKeeper.Now;


### PR DESCRIPTION
## Summary

- Adds `GetTodayCloseUtcAsync()` to `IMarketHoursService` contract so callers can obtain today's NYSE session close time in UTC
- Implements the method in `NyseMarketHoursService` using the existing calendar logic
- Required by the new intraday time-based exit conditions (`IntradayMinutesCondition` and `EndOfDayCondition`) in `MarketData.Brokerage.Primitives`

## Test plan

- [ ] Confirm `NyseMarketHoursService.GetTodayCloseUtcAsync()` returns 21:00 UTC on a regular trading day
- [ ] Confirm method returns the adjusted close for early-close days (e.g., day before Thanksgiving)
- [ ] Confirm any existing `IMarketHoursService` mocks in test projects are updated to satisfy the new interface member
- [ ] Build passes with `dotnet build` across dependent projects

Generated with [Claude Code](https://claude.com/claude-code)